### PR TITLE
List all Tariff Updates in the admin app

### DIFF
--- a/app/controllers/tariff_updates_controller.rb
+++ b/app/controllers/tariff_updates_controller.rb
@@ -1,0 +1,5 @@
+class TariffUpdatesController < ApplicationController
+  def index
+    @tariff_updates = TariffUpdate.all.fetch
+  end
+end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -1,0 +1,39 @@
+class TariffUpdate
+  include Her::Model
+
+  attributes :update_type, :state, :created_at, :updated_at
+
+  collection_path '/updates'
+
+  def state
+    case attributes[:state]
+    when 'A' then 'Applied'
+    when 'M' then 'Missing'
+    when 'P' then 'Pending'
+    when 'F' then 'Failed'
+    end
+  end
+
+  def update_type
+    case attributes[:update_type]
+    when /Taric/ then 'TARIC'
+    when /Chief/ then 'CHIEF'
+    end
+  end
+
+  def missing?
+    attributes[:state] == 'M'
+  end
+
+  def filename
+    super unless missing?
+  end
+
+  def created_at
+    Time.parse(super)
+  end
+
+  def to_s
+    "Applied #{update_type} at #{updated_at} (#{filename})"
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
       <ul class="nav">
         <li><%= link_to 'Sections & Chapters', root_path  %></li>
         <li><%= link_to 'Search Synonyms', sections_path %></li>
+        <li><%= link_to 'Tariff Updates', tariff_updates_path  %></li>
       </ul>
     </div>
   </div>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -1,0 +1,24 @@
+<div class='row'>
+  <h2>Tariff Updates</h2>
+
+  <table class='table table-bordered table-striped table-condensed table-tariff-updates'>
+    <thead>
+      <tr>
+        <th class='span2'>Update type</th>
+        <th class='span2'>File name</th>
+        <th class='span2'>State</th>
+        <th class='span2'>Created at</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @tariff_updates.each do |tariff_update| %>
+        <tr id='<%= dom_id(tariff_update) %>'>
+          <td><%= tariff_update.update_type %></td>
+          <td><%= tariff_update.filename %></td>
+          <td><%= tariff_update.state %></td>
+          <td><%= tariff_update.created_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ TradeTariffAdmin::Application.routes.draw do
       end
     end
 
+    resources :tariff_updates, only: [:index]
+
     post "preview" => "previewer#render", as: :preview
     get  "healthcheck" => "healthcheck#check", as: :healthcheck
     get  "/" => "pages#index", as: :index

--- a/spec/factories/tariff_update_factory.rb
+++ b/spec/factories/tariff_update_factory.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :tariff_update do
+    update_type { ['TariffSynchronizer::TaricUpdate', 'TariffSynchronizer::ChiefUpdate'].sample }
+    state { ['A', 'M', 'P', 'F'].sample }
+    updated_at { Time.now }
+    created_at { Time.now }
+
+    trait :chief do
+      update_type { 'TariffSynchronizer::ChiefUpdate' }
+    end
+
+    trait :taric do
+      update_type { 'TariffSynchronizer::TaricUpdate' }
+    end
+
+    trait :missing do
+      state { 'M' }
+    end
+  end
+end

--- a/spec/features/tariff_updates_spec.rb
+++ b/spec/features/tariff_updates_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe "Tariff Update listing" do
+  let!(:user)   { create :user, :gds_editor }
+  let(:tariff_update) { attributes_for(:tariff_update, :chief, :missing) }
+
+  before {
+    stub_api_for(TariffUpdate) { |stub|
+      stub.get("/updates") { |env|
+        api_success_response([tariff_update])
+      }
+    }
+  }
+
+  it "lists all tariff updates" do
+    visit tariff_updates_path
+
+    expect(page).to have_content 'CHIEF'
+    expect(page).to have_content 'Missing'
+  end
+end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/57381324 and depends on https://github.com/alphagov/trade-tariff-backend/pull/110.

Lists all Tariff updates in the admin app.
