### PR TITLE
Use bearer token strategy for cross app communication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < Sequel::Model
   end
 
   def self.user_params_from_auth_hash(auth_hash)
-    GDS::SSO::User.user_params_from_auth_hash(auth_hash.to_hash).merge(access_token: auth_hash.credentials.token)
+    GDS::SSO::User.user_params_from_auth_hash(auth_hash.to_hash)
   end
 
   def self.find_by_uid(uid)

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -3,6 +3,4 @@ GDS::SSO.config do |config|
   config.oauth_id     = ENV['TARIFF_ADMIN_OAUTH_ID'] || "abcdefghjasndjkasndpublisher"
   config.oauth_secret = ENV['TARIFF_ADMIN_OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
-  # config.basic_auth_user = ENV['PANOPTICON_USER'] || "api"
-  # config.basic_auth_password = ENV['PANOPTICON_PASSWORD'] || "defined_on_rollout_not"
 end

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -1,7 +1,7 @@
 Her::API.setup url: Rails.application.config.api_host do |c|
-  c.use Faraday::Request::BasicAuthentication, ENV['TRADE_TARIFF_USER'], ENV['TRADE_TARIFF_PASSWORD']
   c.use Faraday::Request::UrlEncoded
   c.use Her::Middleware::AcceptJSON
+  c.use Her::Middleware::BearerTokenAuthentication, ENV['BEARER_TOKEN'] # lib/her/middleware/bearer_token_authentication.rb
   c.use Her::Middleware::HeaderMetadataParse # lib/her/middleware/header_metadata_parse.rb
   c.use Her::Middleware::DefaultParseJSON
   c.use Faraday::Adapter::NetHttp

--- a/lib/her/middleware/bearer_token_authentication.rb
+++ b/lib/her/middleware/bearer_token_authentication.rb
@@ -1,0 +1,20 @@
+module Her
+  module Middleware
+    class BearerTokenAuthentication < Faraday::Middleware
+       def initialize(app, token = nil)
+         super(app)
+         @token = token && token.to_s
+      end
+
+      def call(env)
+        env[:request_headers][:authorization] = authorization_header
+
+        @app.call(env)
+      end
+
+      def authorization_header
+        "Bearer #{@token}"
+      end
+    end
+  end
+end

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -1,3 +1,4 @@
+require 'her/middleware/bearer_token_authentication'
 require 'her/middleware/header_metadata_parse'
 
 module TradeTariffAdmin


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/58791864

And should solve issues https://github.com/alphagov/trade-tariff-admin/issues/6 and https://github.com/alphagov/trade-tariff-admin/issues/5.

In order for this to work we need to create an API client user on signonotron:

```
rake api_clients:create[name,email,application_name,permission]
```

See full task description here https://github.com/alphagov/signonotron2/blob/master/lib/tasks/api_clients.rake#L2-L15. Permission is just `signin`.

Then `her.rb` in alphagov-deployment will have to be modified to reflect these changes and `ENV['BEARER_TOKEN']` replaced with token that Signonotron will generate after task run.

Requires merge on tariff backend's pull request https://github.com/alphagov/trade-tariff-backend/pull/116.
