### PR TITLE
Rollback management implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "addressable", "2.3.5"
 gem "unicorn", "~> 4.6.3"
 
 gem "jquery-rails", "3.0.4"
+gem "bootstrap-datepicker-rails", "~> 1.1.1.11"
 gem 'logstasher', '0.4.1'
 gem "aws-ses", require: "aws/ses" # Needed by exception_notification
 gem "exception_notification", "4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
+    bootstrap-datepicker-rails (1.1.1.11)
+      railties (>= 3.0)
     brakeman (1.7.1)
       activesupport
       erubis (~> 2.6)
@@ -275,6 +277,7 @@ PLATFORMS
 DEPENDENCIES
   addressable (= 2.3.5)
   aws-ses
+  bootstrap-datepicker-rails (~> 1.1.1.11)
   brakeman (~> 1.7.0)
   capybara (~> 2.1.0)
   ci_reporter

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap-datepicker
 //= require twitter/bootstrap
 //= require jquery.autosize
 //= require_tree .

--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -1,0 +1,5 @@
+$(document).ready(function(){
+  $('[data-behaviour~=datepicker]').datepicker({
+    format: 'dd/mm/yyyy'
+  });
+})

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,5 +1,6 @@
 /*
  *= require_tree .
+ *= require bootstrap-datepicker
  */
 
 table#application-list tbody tr td.in-sync, table#application-list tbody tr td.in-sync:hover {

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -56,3 +56,15 @@ td.icon {
 .modal input.span5 {
   width: 520px;
 }
+
+.control-group {
+  .help-block {
+    font-style: italic;
+  }
+
+  &.date {
+    select {
+      width: auto
+    }
+  }
+}

--- a/app/controllers/rollbacks_controller.rb
+++ b/app/controllers/rollbacks_controller.rb
@@ -1,0 +1,27 @@
+class RollbacksController < ApplicationController
+  def index
+    @rollbacks = Rollback.all.fetch
+  end
+
+  def new
+    @rollback = Rollback.new
+  end
+
+  def create
+    @rollback = Rollback.new(rollback_params)
+
+    if @rollback.save
+      redirect_to rollbacks_path, notice: 'Rollback was scheduled'
+    else
+      @rollback.initialize_errors
+
+      render :new
+    end
+  end
+
+  private
+
+  def rollback_params
+    params.require(:rollback).permit(:date, :redownload)
+  end
+end

--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -1,0 +1,17 @@
+class Rollback
+  include Her::Model
+
+  attributes :jid, :enqueued_at, :redownload, :date
+
+  collection_path '/rollbacks'
+
+  include_root_in_json true
+
+  def initialize_errors
+    response_errors.each do |attribute, error_messages|
+      Array(error_messages).each do |error_message|
+        errors.add(attribute, error_message)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
             <%= nav_link 'Section & chapter notes', root_path, /\/notes|trade-tariff-admin$/ %>
             <%= nav_link 'Search Synonyms', synonyms_sections_path, /\/synonyms/ %>
             <%= nav_link 'Tariff Updates', tariff_updates_path, /\/tariff_updates/ %>
+            <%= nav_link 'Rollbacks', rollbacks_path, /\/rollbacks/ %>
           </ul>
           <ul class="nav pull-right">
             <li class="dropdown">

--- a/app/views/rollbacks/index.html.erb
+++ b/app/views/rollbacks/index.html.erb
@@ -1,0 +1,32 @@
+<h2>
+  Database rollbacks
+
+  <%= link_to 'New Rollback', new_rollback_path, class: 'btn btn-small pull-right' %>
+</h2>
+
+<% if @rollbacks.any? %>
+  <table class='table table-bordered table-striped table-condensed rollbacks'>
+    <thead>
+      <tr>
+        <th class='span2'>Job ID</th>
+        <th class='span2'>Rollback to (date)</th>
+        <th class='span2'>Redownload?</th>
+        <th class='span2'>Scheduled at</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @rollbacks.each do |rollback| %>
+        <tr id='<%= dom_id(rollback) %>'>
+          <td><%= rollback.jid %></td>
+          <td><%= rollback.date %></td>
+          <td><%= rollback.redownload %></td>
+          <td><%= rollback.enqueued_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class='alert alert-info'>
+    <strong>No database rollback jobs are enqueued at this time.</strong>
+  </div>
+<% end %>

--- a/app/views/rollbacks/new.html.erb
+++ b/app/views/rollbacks/new.html.erb
@@ -1,0 +1,17 @@
+<div class="page-header">
+  <h1>New Rollback</h1>
+</div>
+
+<%= simple_form_for @rollback do |f| %>
+  <div class='row'>
+    <div class='span12'>
+      <%= f.input :date, as: :string, label: 'Rollback to (date)',  input_html: { class: 'span6', 'data-behaviour' => 'datepicker' } %>
+      <%= f.input :redownload, as: :boolean, label: 'Redownload', hint: 'Deletes and redownload update files since specified date',  input_html: { class: 'span6' } %>
+    </div>
+  </div>
+
+  <div class='form-actions'>
+    <%= f.button :submit, class: 'btn btn-primary', data: { 'disable-with' => 'Working' } %>
+    <%= link_to "Back", :back, class: 'btn' %>
+  </div>
+<% end %>

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -3,6 +3,6 @@ Her::API.setup url: Rails.application.config.api_host do |c|
   c.use Her::Middleware::AcceptJSON
   c.use Her::Middleware::BearerTokenAuthentication, ENV['BEARER_TOKEN'] # lib/her/middleware/bearer_token_authentication.rb
   c.use Her::Middleware::HeaderMetadataParse # lib/her/middleware/header_metadata_parse.rb
-  c.use Her::Middleware::DefaultParseJSON
+  c.use Her::Middleware::FirstLevelParseJSON
   c.use Faraday::Adapter::NetHttp
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ TradeTariffAdmin::Application.routes.draw do
   end
 
   resources :tariff_updates, only: [:index]
+  resources :rollbacks, only: [:index, :new, :create]
 
   post "govspeak" => "govspeak#govspeak", as: :govspeak
   get  "healthcheck" => "healthcheck#check", as: :healthcheck

--- a/spec/factories/rollback_factory.rb
+++ b/spec/factories/rollback_factory.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :rollback do
+    jid { 10.times.map{ Random.rand(9) + 1 }.join }
+    enqueued_at { Date.today.to_date }
+    redownload { [true, false].sample }
+    date { Date.today.ago(1.month).to_date }
+  end
+end

--- a/spec/features/rollbacks_spec.rb
+++ b/spec/features/rollbacks_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe "Rollbacks management" do
+  let!(:user)   { create :user, :gds_editor }
+
+  describe "Rollback creation" do
+    let(:rollback)      { build :rollback }
+
+    specify do
+      stub_api_for(Rollback) { |stub|
+        stub.get("/rollbacks") { |env|
+          api_success_response([])
+        }
+      }
+
+      refute rollback_created(rollback)
+
+      stub_api_for(Rollback) { |stub|
+        stub.post("/rollbacks") { |env|
+          api_created_response
+        }
+
+        stub.get("/rollbacks") { |env|
+          api_success_response([rollback.attributes])
+        }
+      }
+
+      create_rollback(rollback)
+
+      verify rollback_created(rollback)
+    end
+  end
+
+  private
+
+  def rollback_created(rollback)
+    ensure_on rollbacks_path
+
+    page.has_selector?("table.rollbacks") &&
+      page.has_content?(rollback.date)
+  end
+
+  def create_rollback(rollback)
+    ensure_on new_rollback_path
+
+    fill_in "rollback_date", with: rollback.date
+
+    click_button 'Create Rollback'
+  end
+end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/50000203

Allows scheduling database rollbacks from the admin ui. Talks with backend API in order to accomplish this.

Related to:
- https://github.com/alphagov/trade-tariff-backend/pull/137
