### PR TITLE
Store backtrace/SQL queries of failed syncs in the DB

### DIFF
--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -1,7 +1,7 @@
 class TariffUpdate
   include Her::Model
 
-  attributes :update_type, :state, :created_at, :updated_at, :applied_at, :filesize
+  attributes :update_type, :state, :created_at, :updated_at, :applied_at, :filesize, :exception_backtrace, :exception_class, :exception_queries
 
   collection_path '/updates'
 

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -9,6 +9,7 @@
       <th class='span2'>Created at</th>
       <th class='span2'>Applied at</th>
       <th class='span2'>File size</th>
+      <th class='span2'>Exception</th>
     </tr>
   </thead>
   <tbody>
@@ -20,6 +21,17 @@
         <td><%= tariff_update.created_at %></td>
         <td><%= tariff_update.applied_at %></td>
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
+        <td>
+          <strong><%= tariff_update.exception_class %></strong>
+          <% if tariff_update.exception_queries %>
+            <div>queries:</div>
+            <pre><%= tariff_update.exception_queries %></pre>
+          <% end %>
+          <% if tariff_update.exception_backtrace %>
+            <div>backtrace:</div>
+            <pre><%= tariff_update.exception_backtrace %></pre>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/factories/tariff_update_factory.rb
+++ b/spec/factories/tariff_update_factory.rb
@@ -13,6 +13,12 @@ FactoryGirl.define do
       update_type { 'TariffSynchronizer::TaricUpdate' }
     end
 
+    trait :with_exception do
+      exception_class "ChiefImporter::ImportException"
+      exception_queries "(Sequel::Mysql2::Database) BEGIN \n(Sequel::Mysql2::Database) SELECT * FROM `measures` LIMIT 1 \n(Sequel::Mysql2::Database) ROLLBACK \n(Sequel::Mysql2::Database) UPDATE `tariff_updates` SET `state` = 'F', `updated_at` = '2014-07-22 16:16:15' WHERE ((`tariff_updates`.`update_type` IN ('TariffSynchronizer::TaricUpdate')) AND (`filename` = '2014-07-22_TGB14203.xml')) LIMIT 1 "
+      exception_backtrace "/var/govuk/trade-tariff-backend/spec/unit/tariff_synchronizer/logger_spec.rb:179:in `block (4 levels) in <top (required)>'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:519:in `call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:519:in `block in call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:518:in `map'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:518:in `call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:186:in `invoke'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/proxy.rb:144:in `message_received'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/method_double.rb:174:in `import'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/any_instance/recorder.rb:187:in `import'"
+    end
+
     trait :missing do
       state { 'M' }
     end

--- a/spec/features/tariff_updates_spec.rb
+++ b/spec/features/tariff_updates_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Tariff Update listing" do
   let!(:user)   { create :user, :gds_editor }
-  let(:tariff_update) { attributes_for(:tariff_update, :chief, :missing) }
+  let(:tariff_update) { attributes_for(:tariff_update, :chief, :missing, :with_exception) }
 
   before {
     stub_api_for(TariffUpdate) { |stub|
@@ -17,5 +17,8 @@ describe "Tariff Update listing" do
 
     expect(page).to have_content 'CHIEF'
     expect(page).to have_content 'Missing'
+    expect(page).to have_content "ChiefImporter::ImportException"
+    expect(page).to have_content "logger_spec.rb:179"
+    expect(page).to have_content "(Sequel::Mysql2::Database)"
   end
 end


### PR DESCRIPTION
compliments alphagov/trade-tariff-backend#192

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/71632648)
