### PR TITLE
[81507580] minor formatting change to tariff updates' date

### DIFF
--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -7,6 +7,10 @@ class Rollback
 
   include_root_in_json true
 
+  def enqueued_at
+    Time.parse(super) if super.present?
+  end
+
   def user=(user)
     self.user_id = user.id
   end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -33,6 +33,10 @@ class TariffUpdate
     Time.parse(super)
   end
 
+  def applied_at
+    Time.parse(super) if super.present?
+  end
+
   def to_s
     "Applied #{update_type} at #{updated_at} (#{filename})"
   end

--- a/app/views/rollbacks/index.html.erb
+++ b/app/views/rollbacks/index.html.erb
@@ -24,7 +24,7 @@
           <td><%= rollback.reason %></td>
           <td><%= rollback.date %></td>
           <td><%= rollback.keep %></td>
-          <td><%= rollback.enqueued_at %></td>
+          <td><%= l(rollback.enqueued_at, format: :tariff) if rollback.enqueued_at %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -39,8 +39,8 @@
             <% end %>
           <% end %>
         </td>
-        <td><%= tariff_update.created_at %></td>
-        <td><%= tariff_update.applied_at %></td>
+        <td><%= l tariff_update.created_at, format: :tariff %></td>
+        <td><%= l(tariff_update.applied_at, format: :tariff) if tariff_update.applied_at %></td>
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
       </tr>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,6 @@
 
 en:
   hello: "Hello world"
+  time:
+    formats:
+      tariff: "%d/%m/%Y %H:%M:%S %Z"


### PR DESCRIPTION
Add `tariff` formatting for `Time` objects. Uses `dd/mm/yyyy` allowing to copy & paste inside rollback _datepicker_.
Also add some parsing of times for `TariffUpdate` and `Rollback` models to keep all times in the same format.

[PT](https://www.pivotaltracker.com/story/show/81507580)
