### PR TITLE
add `bundler:audit` rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "airbrake", "3.1.16"
 
 group :development, :test do
   gem "pry-rails"
+  gem "bundler-audit"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    bundler-audit (0.3.1)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -294,6 +297,7 @@ DEPENDENCIES
   airbrake (= 3.1.16)
   bootstrap-datepicker-rails (~> 1.1.1.11)
   brakeman (~> 1.7.0)
+  bundler-audit
   capybara (~> 2.4.0)
   ci_reporter
   ci_reporter_rspec

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,10 @@
+require "bundler/audit/cli"
+
+namespace :bundler do
+  desc "Updates the ruby-advisory-db and runs audit"
+  task :audit do
+    %w(update check).each do |command|
+      Bundler::Audit::CLI.start [command]
+    end
+  end
+end


### PR DESCRIPTION
Adding a rake task for [budler-audit](https://github.com/rubysec/bundler-audit) which checks for vulnerable versions of gems in Gemfile.lock file.

- run with `bundle exec rake bundler:audit`