### PR TITLE
Remove duplicated jquery-rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "addressable", "~> 2.3"
 
 gem "unicorn", "~> 4.8"
 
-gem "jquery-rails", "~> 3.1.3"
 gem "bootstrap-datepicker-rails", "~> 1.3"
 gem "logstasher", "~> 0.6"
 gem "airbrake", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,6 @@ DEPENDENCIES
   govspeak (~> 3.3)
   govuk_admin_template (~> 2.3.1)
   her (= 0.6.8)
-  jquery-rails (~> 3.1.3)
   kaminari (~> 0.16)
   logstasher (~> 0.6)
   mysql2 (~> 0.3)


### PR DESCRIPTION
govuk_admin_template pulls in jquery-rails, so we don't need the requirement in gemfile